### PR TITLE
修复SUMMARY,章节名拼写错误

### DIFF
--- a/ZH/6.0/部署指南/SUMMARY.md
+++ b/ZH/6.0/部署指南/SUMMARY.md
@@ -43,7 +43,7 @@
             * [Consul](产品白皮书/维护手册/日常维护/consul.md)
             * [MongoDB](产品白皮书/维护手册/日常维护/mongodb.md)
             * [MySQL](产品白皮书/维护手册/日常维护/mysql.md)
-            * [Kafka](产品白皮书/维护手册/日常维护/zookeeper.md)
+            * [Zookeeper](产品白皮书/维护手册/日常维护/zookeeper.md)
             * [Kafka](产品白皮书/维护手册/日常维护/kafka.md)
             * [更新证书](产品白皮书/维护手册/日常维护/renew_certificate.md)
         * [升级指引]()


### PR DESCRIPTION
# 描述

1. 适用版本：社区版 6.0
2. 更新内容：
    - fix：修复zookeeper章节名拼写错误
