### PR TITLE
Update install-bkce.md

### DIFF
--- a/ZH/7.0/部署指南/install-bkce.md
+++ b/ZH/7.0/部署指南/install-bkce.md
@@ -122,7 +122,7 @@ k8s node 需要能从 bkrepo 中拉取镜像。因此需要配置 DNS 。
 ``` bash
 cd ~/bkhelmfile/blueking/  # 进入工作目录
 BK_DOMAIN=$(yq e '.domain.bkDomain' environments/default/custom.yaml)  # 从自定义配置中提取, 也可自行赋值
-IP1=$(kubectl -A get svc -l app.kubernetes.io/instance=ingress-nginx -o jsonpath='{.items[0].spec.clusterIP}')
+IP1=$(kubectl get svc -A -l app.kubernetes.io/instance=ingress-nginx -o jsonpath='{.items[0].spec.clusterIP}')
 cat <<EOF
 $IP1 $BK_DOMAIN
 $IP1 bkrepo.$BK_DOMAIN


### PR DESCRIPTION
配置 k8s node 的 DNS这里获取IP时，语法错误，应该是IP1=$(kubectl get svc -A -l app.kubernetes.io/instance=ingress-nginx -o jsonpath='{.items[0].spec.clusterIP}')

# 描述

1. 适用版本：社区版 6.0
2. 更新内容：
    - feat：新增部分
    - fix：修补 bug
    - style：格式更新
    - refactor：重构文档结构
3. fix # Issues

## Check list

- [ ] 文档内容正确，命令等经过测试
- [ ] 通篇文档阅读过一遍，无错别字、歧义之处
- [ ] 通过 markdown 语法检查（https://github.com/lint-md/lint-md）
